### PR TITLE
Apply pull request 40 code changes

### DIFF
--- a/com.vogella.lsp.asciidoc.server/src/com/vogella/lsp/asciidoc/server/AsciidocLanguageServer.java
+++ b/com.vogella.lsp.asciidoc.server/src/com/vogella/lsp/asciidoc/server/AsciidocLanguageServer.java
@@ -37,6 +37,7 @@ public class AsciidocLanguageServer implements LanguageServer {
 		res.getCapabilities().setDefinitionProvider(Boolean.TRUE);
 		res.getCapabilities().setCodeActionProvider(Boolean.TRUE);
 		res.getCapabilities().setCodeLensProvider(new CodeLensOptions(false));
+		res.getCapabilities().setDocumentLinkProvider(Boolean.TRUE);
 //		res.getCapabilities().setReferencesProvider(Boolean.TRUE);
 		return CompletableFuture.supplyAsync(() -> res);
 	}


### PR DESCRIPTION
This commit applies the changes from PR #40 to connect the AsciiDoc LSP server to production .adoc files, and implements issue #29 to migrate hyperlink detection to LSP Document Link Provider.

Changes for PR #40:
- Connect LSP server to com.vogella.editor.asciidoc.contenttype
- Add languageId="asciidoc" for proper LSP protocol compliance
- Update server label to "AsciiDoc Language Server"
- Improve ID naming with plugin prefix
- Add MANIFEST.MF dependency on com.vogella.ide.editor.asciidoc

Changes for issue #29:
- Add DocumentLinkProvider capability to AsciidocLanguageServer
- Implement documentLink() method in AsciidocTextDocumentService
- Support include:: links with relative path resolution
- Support image:: links with img/ subdirectory handling
- Support link: references for both external URLs and internal files
- Validate target file existence before creating links
- Handle cross-platform path separators

This migrates functionality from the Eclipse editor hyperlink detectors (IncludeHyperlinkDetector, ImageHyperlinkDetector, LinkHyperlinkDetector) to standardized LSP Document Links, enabling Ctrl+Click navigation.