### PR TITLE
Add WARNING block code completion for Asciidoc

### DIFF
--- a/com.vogella.lsp.asciidoc.server/src/com/vogella/lsp/asciidoc/server/AsciidocTextDocumentService.java
+++ b/com.vogella.lsp.asciidoc.server/src/com/vogella/lsp/asciidoc/server/AsciidocTextDocumentService.java
@@ -1367,7 +1367,7 @@ public class AsciidocTextDocumentService implements TextDocumentService {
 		items.add(include);
 
 		// WARNING admonition block
-		CompletionItem warning = new CompletionItem("[WARNING]");
+		CompletionItem warning = new CompletionItem("WARNING");
 		warning.setKind(CompletionItemKind.Snippet);
 		warning.setInsertText("[WARNING]\n====\n${1:}\n====");
 		warning.setInsertTextFormat(InsertTextFormat.Snippet);


### PR DESCRIPTION
Added code completion template for WARNING admonition blocks in the AsciiDoc LSP server. When users type "WA" and press CTRL+Space, they will now see a completion option that inserts:

[WARNING]
====
*CURSOR HERE*
====

The cursor will be positioned inside the block for immediate content entry.