### PR TITLE
Add JSON schema validation example bundle

### DIFF
--- a/com.vogella.adapters/META-INF/MANIFEST.MF
+++ b/com.vogella.adapters/META-INF/MANIFEST.MF
@@ -15,5 +15,5 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.e4.ui.workbench
 Bundle-RequiredExecutionEnvironment: JavaSE-25
-Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)"
+Import-Package: jakarta.annotation;version="[2.1.0,4.0.0)"
 Automatic-Module-Name: com.vogella.adapters

--- a/com.vogella.contribute.parts/META-INF/MANIFEST.MF
+++ b/com.vogella.contribute.parts/META-INF/MANIFEST.MF
@@ -18,6 +18,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.workbench;bundle-version="3.134.0",
  org.eclipse.e4.core.contexts
 Bundle-RequiredExecutionEnvironment: JavaSE-25
-Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)",
+Import-Package: jakarta.annotation;version="[2.1.0,4.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)"
 Automatic-Module-Name: com.vogella.contribute.parts

--- a/com.vogella.ide.first/META-INF/MANIFEST.MF
+++ b/com.vogella.ide.first/META-INF/MANIFEST.MF
@@ -12,6 +12,6 @@ Require-Bundle: org.eclipse.osgi,
  org.eclipse.e4.core.di.annotations
 Bundle-RequiredExecutionEnvironment: JavaSE-25
 Import-Package: com.vogella.tasks.model,
- jakarta.annotation;version="[2.1.0,3.0.0)",
+ jakarta.annotation;version="[2.1.0,4.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)"
 Automatic-Module-Name: com.vogella.ide.first

--- a/com.vogella.json.validation.tests/.classpath
+++ b/com.vogella.json.validation.tests/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-25"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/com.vogella.json.validation.tests/.project
+++ b/com.vogella.json.validation.tests/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.vogella.json.validation.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/com.vogella.json.validation.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/com.vogella.json.validation.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=25
+org.eclipse.jdt.core.compiler.compliance=25
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=25

--- a/com.vogella.json.validation.tests/META-INF/MANIFEST.MF
+++ b/com.vogella.json.validation.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: JSON Schema Validation Example Tests
+Bundle-SymbolicName: com.vogella.json.validation.tests
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: VOGELLA
+Fragment-Host: com.vogella.json.validation;bundle-version="1.0.0"
+Require-Bundle: junit-jupiter-api;bundle-version="5.11.0"
+Automatic-Module-Name: com.vogella.json.validation.tests
+Bundle-RequiredExecutionEnvironment: JavaSE-25

--- a/com.vogella.json.validation.tests/build.properties
+++ b/com.vogella.json.validation.tests/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/com.vogella.json.validation.tests/pom.xml
+++ b/com.vogella.json.validation.tests/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.vogella.tycho</groupId>
+		<artifactId>releng</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+
+	<groupId>com.vogella.json</groupId>
+	<artifactId>com.vogella.json.validation.tests</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>eclipse-test-plugin</packaging>
+
+</project>

--- a/com.vogella.json.validation.tests/src/com/vogella/json/validation/tests/JsonSchemaValidationExampleTest.java
+++ b/com.vogella.json.validation.tests/src/com/vogella/json/validation/tests/JsonSchemaValidationExampleTest.java
@@ -1,0 +1,55 @@
+package com.vogella.json.validation.tests;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.networknt.schema.ValidationMessage;
+import com.vogella.json.validation.JsonSchemaValidationExample;
+
+class JsonSchemaValidationExampleTest {
+
+	private final JsonSchemaValidationExample example = new JsonSchemaValidationExample();
+
+	@Test
+	void validDocumentHasNoErrors() throws Exception {
+		try (InputStream schema = schema(); InputStream data = resource("data.json")) {
+			Set<ValidationMessage> errors = example.validate(schema, data);
+			assertTrue(errors.isEmpty(), () -> "Expected no errors but got: " + errors);
+		}
+	}
+
+	@Test
+	void invalidDocumentReportsErrors() throws Exception {
+		// Missing required "name", negative "age", and an undeclared property.
+		String invalid = """
+				{
+				  "age": -1,
+				  "unexpected": true
+				}
+				""";
+		try (InputStream schema = schema();
+				InputStream data = new ByteArrayInputStream(invalid.getBytes(StandardCharsets.UTF_8))) {
+			Set<ValidationMessage> errors = example.validate(schema, data);
+			assertFalse(errors.isEmpty(), "Expected validation errors for an invalid document");
+		}
+	}
+
+	private static InputStream schema() {
+		return resource("schema.json");
+	}
+
+	private static InputStream resource(String name) {
+		InputStream in = JsonSchemaValidationExample.class.getResourceAsStream(name);
+		if (in == null) {
+			throw new IllegalStateException("Missing classpath resource: " + name);
+		}
+		return in;
+	}
+}

--- a/com.vogella.json.validation/.classpath
+++ b/com.vogella.json.validation/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-25"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/com.vogella.json.validation/.project
+++ b/com.vogella.json.validation/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.vogella.json.validation</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/com.vogella.json.validation/.settings/org.eclipse.jdt.core.prefs
+++ b/com.vogella.json.validation/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=25
+org.eclipse.jdt.core.compiler.compliance=25
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=25

--- a/com.vogella.json.validation/META-INF/MANIFEST.MF
+++ b/com.vogella.json.validation/META-INF/MANIFEST.MF
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: JSON Schema Validation Example
+Bundle-SymbolicName: com.vogella.json.validation
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: VOGELLA
+Automatic-Module-Name: com.vogella.json.validation
+Bundle-RequiredExecutionEnvironment: JavaSE-25
+Export-Package: com.vogella.json.validation
+Require-Bundle: com.networknt.json-schema-validator;bundle-version="1.5.6",
+ com.fasterxml.jackson.core.jackson-databind;bundle-version="[2.18.0,3.0.0)"

--- a/com.vogella.json.validation/build.properties
+++ b/com.vogella.json.validation/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/com.vogella.json.validation/src/com/vogella/json/validation/JsonSchemaValidationExample.java
+++ b/com.vogella.json.validation/src/com/vogella/json/validation/JsonSchemaValidationExample.java
@@ -1,0 +1,64 @@
+package com.vogella.json.validation;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+
+/**
+ * Validates a JSON document against a JSON Schema (Draft 2020-12) using
+ * networknt/json-schema-validator.
+ */
+public class JsonSchemaValidationExample {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+	private static final JsonSchemaFactory FACTORY = JsonSchemaFactory
+			.getInstance(SpecVersion.VersionFlag.V202012);
+
+	/**
+	 * Validates the JSON read from {@code data} against the schema read from
+	 * {@code schema}.
+	 *
+	 * @return the validation errors, empty if the document is valid
+	 */
+	public Set<ValidationMessage> validate(InputStream schema, InputStream data) {
+		try {
+			JsonSchema jsonSchema = FACTORY.getSchema(schema);
+			JsonNode node = MAPPER.readTree(data);
+			return jsonSchema.validate(node);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read JSON schema or data", e);
+		}
+	}
+
+	public static void main(String[] args) {
+		JsonSchemaValidationExample example = new JsonSchemaValidationExample();
+		try (InputStream schema = resource("schema.json");
+				InputStream data = resource("data.json")) {
+			Set<ValidationMessage> errors = example.validate(schema, data);
+			if (errors.isEmpty()) {
+				System.out.println("data.json is valid against schema.json");
+			} else {
+				System.out.println("data.json is invalid:");
+				errors.forEach(error -> System.out.println("  " + error.getMessage()));
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	private static InputStream resource(String name) {
+		InputStream in = JsonSchemaValidationExample.class.getResourceAsStream(name);
+		if (in == null) {
+			throw new IllegalStateException("Missing classpath resource: " + name);
+		}
+		return in;
+	}
+}

--- a/com.vogella.json.validation/src/com/vogella/json/validation/data.json
+++ b/com.vogella.json.validation/src/com/vogella/json/validation/data.json
@@ -1,0 +1,5 @@
+{
+  "name": "Alice",
+  "age": 30,
+  "email": "alice@example.com"
+}

--- a/com.vogella.json.validation/src/com/vogella/json/validation/schema.json
+++ b/com.vogella.json.validation/src/com/vogella/json/validation/schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "age": { "type": "integer", "minimum": 0 },
+    "email": { "type": "string", "format": "email" }
+  },
+  "required": ["name", "age"],
+  "additionalProperties": false
+}

--- a/com.vogella.tasks.ui/META-INF/MANIFEST.MF
+++ b/com.vogella.tasks.ui/META-INF/MANIFEST.MF
@@ -24,7 +24,7 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-RequiredExecutionEnvironment: JavaSE-25
 Import-Package: com.vogella.tasks.events,
  com.vogella.tasks.model,
- jakarta.annotation;version="[2.1.0,3.0.0)",
+ jakarta.annotation;version="[2.1.0,4.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)"
 Automatic-Module-Name: com.vogella.tasks.ui
 Bundle-ActivationPolicy: lazy

--- a/pom.xml
+++ b/pom.xml
@@ -140,8 +140,10 @@
     <module>z.ex.search</module>
     <module>com.vogella.ide.iconreplacer</module>
     <module>com.vogella.ide.parallelstart</module>
+    <module>com.vogella.json.validation</module>
 
     <!--Tests-->
+    <module>com.vogella.json.validation.tests</module>
     <!--
 
     <module>com.vogella.tasks.services.tests</module>

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -29,6 +29,12 @@
 					<version>2.11.0</version>
 					<type>jar</type>
 				</dependency>
+				<dependency>
+					<groupId>com.networknt</groupId>
+					<artifactId>json-schema-validator</artifactId>
+					<version>1.5.6</version>
+					<type>jar</type>
+				</dependency>
 			</dependencies>
 		</location>
 	</locations>


### PR DESCRIPTION
Adds a new `com.vogella.json.validation` bundle that shows how to validate a JSON document against a JSON schema using the networknt json-schema-validator, together with a test fragment that covers both the valid and the invalid document case.

The validator is pulled in through the target platform as a Maven location dependency, so it resolves the same way in the IDE and in the Tycho build. Both bundles are wired into the reactor, which means the example is compiled and its tests are executed on every build instead of only living as documentation.