### PR TITLE
Update Tycho to 5.0.4

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,4 +1,4 @@
 -T4
 -Dtycho.localArtifacts=ignore
--Dtycho.version=5.0.2
+-Dtycho.version=5.0.4
 -Dtycho.pomless.parent=${maven.multiModuleProjectDirectory}


### PR DESCRIPTION
Moves the build from Tycho 5.0.2 to 5.0.4. The version is already centralized in `.mvn/maven.config` and referenced from both `.mvn/extensions.xml` and the plugin declarations in the root pom, so this is a one-line change.

Verified locally with a full `./mvnw clean verify` on JDK 25 against the 2026-06 target platform: BUILD SUCCESS with the tests running, 20 passing in the LSP server test bundle and 2 in the JSON validation tests.
